### PR TITLE
Compilation instructions and proper "make install"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ui_*.h
 Makefile
 *.pro.user
 unused/*.hex
+build/  

--- a/README.md
+++ b/README.md
@@ -2,3 +2,23 @@ qlenlab
 =======
 
 Ein alternatives Interface, das die Standard-API der Messhardware “LENlab v3.1” des IBT am KIT (www.ibt.kit.edu) implementiert. Läuft unter Linux und Mac OS, ein Windows-Port ist gerade in Entwicklung. Kommt im Gegensatz zur Original-Software ohne MATLAB aus, baut auf qt4, qwt und fftw auf.
+
+Kompilieren (Unix)
+------------------
+
+Um qlenlab zu kompilieren werden qt4, qwt6 und fftw benötigt. In manchen Fällen (wenn Qt5 und Qt4 installiert ist) muss der Aufruf von `qmake` durch `qmake-qt4` ersetzt werden.
+
+```sh
+$ mkdir build
+$ cd build
+$ qmake ..
+$ make
+```
+
+An diesem Punkt lässt sich die Datei `qlenlab` direkt ausführen, man kann qlenlab aber auch direkt installieren (aus dem Ordner `build`):
+
+```sh
+$ sudo make install
+```
+
+Das Installationsverzeichnis wird nicht wie üblich mit der `DESTDIR`-Variable gesetzt sondern mit `INSTALL_ROOT`.

--- a/qlenlab.pro
+++ b/qlenlab.pro
@@ -39,3 +39,8 @@ HEADERS += qlenlab.h settingsdialog.h exportdialog.h plot.h signaldata.h LENlib/
     fftthread.h
 FORMS +=
 
+target.path = /usr/bin
+SHORTCUT.path = /usr/share/applications
+SHORTCUT.files = $$PWD/qlenlab.desktop
+
+INSTALLS = target SHORTCUT


### PR DESCRIPTION
This adds compilation instructions for Unix systems to the README and enables the use of `make install`.
